### PR TITLE
HHVM nightly is no longer supported on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ php:
   - 5.4
   - 5.5
   - 5.6
+  - 7.0
   - hhvm
-  - hhvm-nightly
 
 install:
   - travis_retry composer install --no-interaction --optimize-autoloader --prefer-source

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,11 @@ php:
   - 7.0
   - hhvm
 
+matrix:
+  allow_failures:
+    - php: 7.0
+  fast_finish: true
+
 install:
   - travis_retry composer install --no-interaction --optimize-autoloader --prefer-source
 


### PR DESCRIPTION
HHVM nightly is no longer supported on Ubuntu Precise. See travis-ci/travis-ci#3788 and facebook/hhvm#5220