### PR TITLE
Make path in shell script independent from cwd

### DIFF
--- a/bin/static-review
+++ b/bin/static-review
@@ -12,4 +12,4 @@
  * @see http://github.com/sjparkinson/static-review/blob/master/LICENSE.md
  */
 
-include('static-review.php');
+include(__DIR__.'/static-review.php');


### PR DESCRIPTION
I usually execute shell scripts from wherever I am and build-/ci-tools do the same.