### PR TITLE
Add support for non-file based reviews

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ $review->review($git->getStagedFiles());
 class NoCommitTagReview extends AbstractReview
 {
     // Review any text based file.
-    public function canReview(FileInterface $file)
+    public function canReviewFile(FileInterface $file)
     {
         $mime = $file->getMimeType();
 
@@ -83,7 +83,7 @@ class NoCommitTagReview extends AbstractReview
     }
 
     // Checks if the file contains `NOCOMMIT`.
-    public function review(ReporterInterface $reporter, FileInterface $file)
+    public function review(ReporterInterface $reporter, ReviewableInterface $file)
     {
         $cmd = sprintf('grep --fixed-strings --ignore-case --quiet "NOCOMMIT" %s', $file->getFullPath());
 

--- a/src/Collection/ReviewCollection.php
+++ b/src/Collection/ReviewCollection.php
@@ -55,7 +55,7 @@ class ReviewCollection extends Collection
      * file.
      *
      * @param  FileInterface $file
-     * @return bool
+     * @return ReviewCollection
      */
     public function forFile(FileInterface $file)
     {

--- a/src/File/File.php
+++ b/src/File/File.php
@@ -175,4 +175,14 @@ class File implements FileInterface
 
         return $mime;
     }
+
+    /**
+     * Get the relative path name as the reviewable name.
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->getRelativePath();
+    }
 }

--- a/src/File/FileInterface.php
+++ b/src/File/FileInterface.php
@@ -13,7 +13,9 @@
 
 namespace StaticReview\File;
 
-interface FileInterface
+use StaticReview\Review\ReviewableInterface;
+
+interface FileInterface extends ReviewableInterface
 {
     public function getFileName();
 

--- a/src/Issue/Issue.php
+++ b/src/Issue/Issue.php
@@ -13,7 +13,7 @@
 
 namespace StaticReview\Issue;
 
-use StaticReview\File\FileInterface;
+use StaticReview\Review\ReviewableInterface;
 use StaticReview\Review\ReviewInterface;
 
 class Issue implements IssueInterface
@@ -32,26 +32,26 @@ class Issue implements IssueInterface
 
     private $review;
 
-    private $file;
+    private $subject;
 
     /**
      * Initializes a new instance of the Issue class.
      *
-     * @param int             $level
-     * @param string          $message
-     * @param ReviewInterface $review
-     * @param FileInterface   $file
+     * @param int                 $level
+     * @param string              $message
+     * @param ReviewInterface     $review
+     * @param ReviewableInterface $subject
      */
     public function __construct(
         $level,
         $message,
         ReviewInterface $review,
-        FileInterface $file
+        ReviewableInterface $subject
     ) {
         $this->level   = $level;
         $this->message = $message;
         $this->review  = $review;
-        $this->file    = $file;
+        $this->subject = $subject;
     }
 
     /**
@@ -81,11 +81,11 @@ class Issue implements IssueInterface
     }
 
     /**
-     * Gets the Issues FileInterface instance.
+     * Gets the Issues Reviewable instance.
      */
-    public function getFile()
+    public function getSubject()
     {
-        return $this->file;
+        return $this->subject;
     }
 
     /**
@@ -152,7 +152,7 @@ class Issue implements IssueInterface
             $this->getReviewName(),
             $this->getLevelName(),
             $this->getMessage(),
-            $this->getFile()->getRelativePath()
+            $this->getSubject()->getName()
         );
     }
 }

--- a/src/Issue/IssueInterface.php
+++ b/src/Issue/IssueInterface.php
@@ -21,5 +21,5 @@ interface IssueInterface
 
     public function getMessage();
 
-    public function getFile();
+    public function getSubject();
 }

--- a/src/Reporter/Reporter.php
+++ b/src/Reporter/Reporter.php
@@ -14,9 +14,9 @@
 namespace StaticReview\Reporter;
 
 use StaticReview\Collection\IssueCollection;
-use StaticReview\File\FileInterface;
 use StaticReview\Issue\Issue;
 use StaticReview\Review\ReviewInterface;
+use StaticReview\Review\ReviewableInterface;
 
 class Reporter implements ReporterInterface
 {
@@ -35,21 +35,21 @@ class Reporter implements ReporterInterface
 
     public function progress($current, $total)
     {
-        echo sprintf("Reviewing file %d of %d.\r", $current, $total);
+        echo sprintf("Reviewing %d of %d.\r", $current, $total);
     }
 
     /**
      * Reports an Issue raised by a Review.
      *
-     * @param  int             $level
-     * @param  string          $message
-     * @param  ReviewInterface $review
-     * @param  FileInterface   $file
+     * @param  int                 $level
+     * @param  string              $message
+     * @param  ReviewInterface     $review
+     * @param  ReviewableInterface $subject
      * @return Reporter
      */
-    public function report($level, $message, ReviewInterface $review, FileInterface $file)
+    public function report($level, $message, ReviewInterface $review, ReviewableInterface $subject)
     {
-        $issue = new Issue($level, $message, $review, $file);
+        $issue = new Issue($level, $message, $review, $subject);
 
         $this->issues->append($issue);
 
@@ -59,14 +59,14 @@ class Reporter implements ReporterInterface
     /**
      * Reports an Info Issue raised by a Review.
      *
-     * @param  string          $message
-     * @param  ReviewInterface $review
-     * @param  FileInterface   $file
+     * @param  string              $message
+     * @param  ReviewInterface     $review
+     * @param  ReviewableInterface $subject
      * @return Reporter
      */
-    public function info($message, ReviewInterface $review, FileInterface $file)
+    public function info($message, ReviewInterface $review, ReviewableInterface $subject)
     {
-        $this->report(Issue::LEVEL_INFO, $message, $review, $file);
+        $this->report(Issue::LEVEL_INFO, $message, $review, $subject);
 
         return $this;
     }
@@ -74,14 +74,14 @@ class Reporter implements ReporterInterface
     /**
      * Reports an Warning Issue raised by a Review.
      *
-     * @param  string          $message
-     * @param  ReviewInterface $review
-     * @param  FileInterface   $file
+     * @param  string              $message
+     * @param  ReviewInterface     $review
+     * @param  ReviewableInterface $subject
      * @return Reporter
      */
-    public function warning($message, ReviewInterface $review, FileInterface $file)
+    public function warning($message, ReviewInterface $review, ReviewableInterface $subject)
     {
-        $this->report(Issue::LEVEL_WARNING, $message, $review, $file);
+        $this->report(Issue::LEVEL_WARNING, $message, $review, $subject);
 
         return $this;
     }
@@ -89,14 +89,14 @@ class Reporter implements ReporterInterface
     /**
      * Reports an Error Issue raised by a Review.
      *
-     * @param  string          $message
-     * @param  ReviewInterface $review
-     * @param  FileInterface   $file
+     * @param  string              $message
+     * @param  ReviewInterface     $review
+     * @param  ReviewableInterface $subject
      * @return Reporter
      */
-    public function error($message, ReviewInterface $review, FileInterface $file)
+    public function error($message, ReviewInterface $review, ReviewableInterface $subject)
     {
-        $this->report(Issue::LEVEL_ERROR, $message, $review, $file);
+        $this->report(Issue::LEVEL_ERROR, $message, $review, $subject);
 
         return $this;
     }

--- a/src/Reporter/ReporterInterface.php
+++ b/src/Reporter/ReporterInterface.php
@@ -13,18 +13,18 @@
 
 namespace StaticReview\Reporter;
 
-use StaticReview\File\FileInterface;
 use StaticReview\Review\ReviewInterface;
+use StaticReview\Review\ReviewableInterface;
 
 interface ReporterInterface
 {
-    public function report($level, $message, ReviewInterface $review, FileInterface $file);
+    public function report($level, $message, ReviewInterface $review, ReviewableInterface $subject);
 
-    public function info($message, ReviewInterface $review, FileInterface $file);
+    public function info($message, ReviewInterface $review, ReviewableInterface $subject);
 
-    public function warning($message, ReviewInterface $review, FileInterface $file);
+    public function warning($message, ReviewInterface $review, ReviewableInterface $subject);
 
-    public function error($message, ReviewInterface $review, FileInterface $file);
+    public function error($message, ReviewInterface $review, ReviewableInterface $subject);
 
     public function hasIssues();
 

--- a/src/Review/AbstractReview.php
+++ b/src/Review/AbstractReview.php
@@ -13,10 +13,24 @@
 
 namespace StaticReview\Review;
 
+use StaticReview\File\FileInterface;
 use Symfony\Component\Process\Process;
 
 abstract class AbstractReview implements ReviewInterface
 {
+    abstract protected function canReviewFile(FileInterface $file);
+
+    /**
+     * Determine if the subject can be reviewed.
+     *
+     * @param  ReviewableInterface $subject
+     * @return boolean
+     */
+    public function canReview(ReviewableInterface $subject)
+    {
+        return $this->canReviewFile($subject);
+    }
+
     /**
      * @param string      $commandline
      * @param null|string $cwd

--- a/src/Review/Composer/ComposerLintReview.php
+++ b/src/Review/Composer/ComposerLintReview.php
@@ -16,7 +16,7 @@ namespace StaticReview\Review\Composer;
 use StaticReview\File\FileInterface;
 use StaticReview\Reporter\ReporterInterface;
 use StaticReview\Review\AbstractReview;
-use Symfony\Component\Process\Process;
+use StaticReview\Review\ReviewableInterface;
 
 class ComposerLintReview extends AbstractReview
 {
@@ -26,7 +26,7 @@ class ComposerLintReview extends AbstractReview
      * @param  FileInterface $file
      * @return bool
      */
-    public function canReview(FileInterface $file)
+    public function canReviewFile(FileInterface $file)
     {
         // only if the filename is "composer.json"
         return ($file->getFileName() === 'composer.json');
@@ -38,7 +38,7 @@ class ComposerLintReview extends AbstractReview
      * @param ReporterInterface $reporter
      * @param FileInterface     $file
      */
-    public function review(ReporterInterface $reporter, FileInterface $file)
+    public function review(ReporterInterface $reporter, ReviewableInterface $file)
     {
         $cmd = sprintf('composer validate %s', $file->getFullPath());
 

--- a/src/Review/Composer/ComposerSecurityReview.php
+++ b/src/Review/Composer/ComposerSecurityReview.php
@@ -16,7 +16,7 @@ namespace StaticReview\Review\Composer;
 use StaticReview\File\FileInterface;
 use StaticReview\Reporter\ReporterInterface;
 use StaticReview\Review\AbstractReview;
-use Symfony\Component\Process\Process;
+use StaticReview\Review\ReviewableInterface;
 
 class ComposerSecurityReview extends AbstractReview
 {
@@ -26,7 +26,7 @@ class ComposerSecurityReview extends AbstractReview
      * @param  FileInterface $file
      * @return bool
      */
-    public function canReview(FileInterface $file)
+    public function canReviewFile(FileInterface $file)
     {
         if ($file->getFileName() === 'composer.lock') {
             return true;
@@ -42,7 +42,7 @@ class ComposerSecurityReview extends AbstractReview
      * @param ReporterInterface $reporter
      * @param FileInterface     $file
      */
-    public function review(ReporterInterface $reporter, FileInterface $file)
+    public function review(ReporterInterface $reporter, ReviewableInterface $file)
     {
         $executable = 'vendor/bin/security-checker';
 

--- a/src/Review/General/LineEndingsReview.php
+++ b/src/Review/General/LineEndingsReview.php
@@ -16,7 +16,7 @@ namespace StaticReview\Review\General;
 use StaticReview\File\FileInterface;
 use StaticReview\Reporter\ReporterInterface;
 use StaticReview\Review\AbstractReview;
-use Symfony\Component\Process\Process;
+use StaticReview\Review\ReviewableInterface;
 
 class LineEndingsReview extends AbstractReview
 {
@@ -28,7 +28,7 @@ class LineEndingsReview extends AbstractReview
      * @param  FileInterface $file
      * @return bool
      */
-    public function canReview(FileInterface $file)
+    public function canReviewFile(FileInterface $file)
     {
         $mime = $file->getMimeType();
 
@@ -41,7 +41,7 @@ class LineEndingsReview extends AbstractReview
      *
      * @link http://stackoverflow.com/a/3570574
      */
-    public function review(ReporterInterface $reporter, FileInterface $file)
+    public function review(ReporterInterface $reporter, ReviewableInterface $file)
     {
         $cmd = sprintf('file %s | grep --fixed-strings --quiet "CRLF"', $file->getFullPath());
 

--- a/src/Review/General/NoCommitTagReview.php
+++ b/src/Review/General/NoCommitTagReview.php
@@ -16,7 +16,7 @@ namespace StaticReview\Review\General;
 use StaticReview\File\FileInterface;
 use StaticReview\Reporter\ReporterInterface;
 use StaticReview\Review\AbstractReview;
-use Symfony\Component\Process\Process;
+use StaticReview\Review\ReviewableInterface;
 
 class NoCommitTagReview extends AbstractReview
 {
@@ -28,7 +28,7 @@ class NoCommitTagReview extends AbstractReview
      * @param  FileInterface $file
      * @return bool
      */
-    public function canReview(FileInterface $file)
+    public function canReviewFile(FileInterface $file)
     {
         $mime = $file->getMimeType();
 
@@ -41,7 +41,7 @@ class NoCommitTagReview extends AbstractReview
      *
      * @link http://stackoverflow.com/a/4749368
      */
-    public function review(ReporterInterface $reporter, FileInterface $file)
+    public function review(ReporterInterface $reporter, ReviewableInterface $file)
     {
         $cmd = sprintf('grep --fixed-strings --ignore-case --quiet "NOCOMMIT" %s', $file->getFullPath());
 

--- a/src/Review/PHP/PhpCodeSnifferReview.php
+++ b/src/Review/PHP/PhpCodeSnifferReview.php
@@ -16,6 +16,7 @@ namespace StaticReview\Review\PHP;
 use StaticReview\File\FileInterface;
 use StaticReview\Reporter\ReporterInterface;
 use StaticReview\Review\AbstractReview;
+use StaticReview\Review\ReviewableInterface;
 
 class PhpCodeSnifferReview extends AbstractReview
 {
@@ -78,7 +79,7 @@ class PhpCodeSnifferReview extends AbstractReview
      * @param  FileInterface $file
      * @return bool
      */
-    public function canReview(FileInterface $file)
+    public function canReviewFile(FileInterface $file)
     {
         return ($file->getExtension() === 'php');
     }
@@ -86,7 +87,7 @@ class PhpCodeSnifferReview extends AbstractReview
     /**
      * Checks PHP files using PHP_CodeSniffer.
      */
-    public function review(ReporterInterface $reporter, FileInterface $file)
+    public function review(ReporterInterface $reporter, ReviewableInterface $file)
     {
         $cmd = 'vendor/bin/phpcs --report=json ';
 

--- a/src/Review/PHP/PhpLeadingLineReview.php
+++ b/src/Review/PHP/PhpLeadingLineReview.php
@@ -16,7 +16,7 @@ namespace StaticReview\Review\PHP;
 use StaticReview\File\FileInterface;
 use StaticReview\Reporter\ReporterInterface;
 use StaticReview\Review\AbstractReview;
-use Symfony\Component\Process\Process;
+use StaticReview\Review\ReviewableInterface;
 
 class PhpLeadingLineReview extends AbstractReview
 {
@@ -26,7 +26,7 @@ class PhpLeadingLineReview extends AbstractReview
      * @param  FileInterface $file
      * @return bool
      */
-    public function canReview(FileInterface $file)
+    public function canReviewFile(FileInterface $file)
     {
         return ($file->getExtension() === 'php');
     }
@@ -37,7 +37,7 @@ class PhpLeadingLineReview extends AbstractReview
      *
      * @link http://stackoverflow.com/a/2440685
      */
-    public function review(ReporterInterface $reporter, FileInterface $file)
+    public function review(ReporterInterface $reporter, ReviewableInterface $file)
     {
         $cmd = sprintf('read -r LINE < %s && echo $LINE', $file->getFullPath());
 

--- a/src/Review/PHP/PhpLintReview.php
+++ b/src/Review/PHP/PhpLintReview.php
@@ -16,6 +16,7 @@ namespace StaticReview\Review\PHP;
 use StaticReview\File\FileInterface;
 use StaticReview\Reporter\ReporterInterface;
 use StaticReview\Review\AbstractReview;
+use StaticReview\Review\ReviewableInterface;
 
 class PhpLintReview extends AbstractReview
 {
@@ -25,7 +26,7 @@ class PhpLintReview extends AbstractReview
      * @param  FileInterface $file
      * @return bool
      */
-    public function canReview(FileInterface $file)
+    public function canReviewFile(FileInterface $file)
     {
         $extension = $file->getExtension();
 
@@ -35,7 +36,7 @@ class PhpLintReview extends AbstractReview
     /**
      * Checks PHP files using the builtin PHP linter, `php -l`.
      */
-    public function review(ReporterInterface $reporter, FileInterface $file)
+    public function review(ReporterInterface $reporter, ReviewableInterface $file)
     {
         $cmd = sprintf('php --syntax-check %s', $file->getFullPath());
 

--- a/src/Review/ReviewableInterface.php
+++ b/src/Review/ReviewableInterface.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of StaticReview
  *
- * Copyright (c) 2014 Samuel Parkinson <@samparkinson_>
+ * Copyright (c) 2015 Woody Gilk <@shadowhand>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -13,11 +13,7 @@
 
 namespace StaticReview\Review;
 
-use StaticReview\Reporter\ReporterInterface;
-
-interface ReviewInterface
+interface ReviewableInterface
 {
-    public function canReview(ReviewableInterface $subject);
-
-    public function review(ReporterInterface $reporter, ReviewableInterface $subject);
+    public function getName();
 }

--- a/src/StaticReview.php
+++ b/src/StaticReview.php
@@ -108,7 +108,7 @@ class StaticReview
      *
      * @return StaticReview
      */
-    public function review(FileCollection $files)
+    public function files(FileCollection $files)
     {
         foreach ($files as $key => $file) {
             $this->getReporter()->progress($key + 1, count($files));

--- a/tests/unit/Issue/IssueTest.php
+++ b/tests/unit/Issue/IssueTest.php
@@ -66,7 +66,7 @@ class IssueTest extends TestCase
 
     /**
      * @expectedException PHPUnit_Framework_Error
-     * @expectedExceptionMessage must implement interface StaticReview\File\FileInterface
+     * @expectedExceptionMessage must implement interface StaticReview\Review\ReviewableInterface
      */
     public function testConstructWithInvalidFile()
     {
@@ -110,9 +110,9 @@ class IssueTest extends TestCase
         $this->assertSame('NoCommitTagReview', $issue->getReviewName());
     }
 
-    public function testGetFile()
+    public function testGetSubject()
     {
-        $this->assertSame($this->issueFile, $this->issue->getFile());
+        $this->assertSame($this->issueFile, $this->issue->getSubject());
     }
 
     public function testGetLevelName()
@@ -205,11 +205,13 @@ class IssueTest extends TestCase
 
     public function testToString()
     {
-        $file = $this->issue->getFile();
+        $file = $this->issue->getSubject();
 
         $file->shouldReceive('getRelativePath')
-             ->twice()
              ->andReturn('/Test');
+
+        $file->shouldReceive('getName')
+             ->andReturn($file->getRelativePath());
 
         $issueString = (string) $this->issue;
 
@@ -219,6 +221,6 @@ class IssueTest extends TestCase
         $this->assertContains($this->issue->getReviewName(), $issueStringTokens);
         $this->assertContains($this->issue->getLevelName(), $issueStringTokens);
         $this->assertContains($this->issue->getMessage(), $issueStringTokens);
-        $this->assertContains($this->issue->getFile()->getRelativePath(), $issueStringTokens);
+        $this->assertContains($this->issue->getSubject()->getRelativePath(), $issueStringTokens);
     }
 }

--- a/tests/unit/Review/AbstractReviewTest.php
+++ b/tests/unit/Review/AbstractReviewTest.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of StaticReview
+ *
+ * Copyright (c) 2014 Samuel Parkinson <@samparkinson_>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @see http://github.com/sjparkinson/static-review/blob/master/LICENSE
+ */
+
+namespace StaticReview\Test\Unit;
+
+use Mockery;
+use PHPUnit_Framework_TestCase as TestCase;
+
+class AbstractReviewTest extends TestCase
+{
+    public function testGetProcess()
+    {
+        $review = Mockery::mock('StaticReview\Review\AbstractReview')->makePartial();
+
+        $process = $review->getProcess('whoami');
+
+        $this->assertInstanceOf('Symfony\Component\Process\Process', $process);
+    }
+}

--- a/tests/unit/StaticReviewTest.php
+++ b/tests/unit/StaticReviewTest.php
@@ -94,6 +94,6 @@ class StaticReviewTest extends TestCase
 
         $this->staticReview->addReviews($reviews);
 
-        $this->assertSame($this->staticReview, $this->staticReview->review($files));
+        $this->assertSame($this->staticReview, $this->staticReview->files($files));
     }
 }


### PR DESCRIPTION
By using a `ReviewableInterface`, it becomes possible to review the commit message as well as the file.

Doing so requires referencing the new interface instead `FileInterface` in a number of places, as well as reworking methods to retain maximum backwards compatibility.