### PR TITLE
Add commit message review

### DIFF
--- a/hooks/static-review-commit-msg.php
+++ b/hooks/static-review-commit-msg.php
@@ -1,0 +1,80 @@
+#!/usr/bin/env php
+<?php
+
+/*
+ * This file is part of StaticReview
+ *
+ * Copyright (c) 2015 Woody Gilk <@shadowhand>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @see http://github.com/sjparkinson/static-review/blob/master/LICENSE
+ */
+
+$included = include file_exists(__DIR__ . '/../vendor/autoload.php')
+    ? __DIR__ . '/../vendor/autoload.php'
+    : __DIR__ . '/../../../autoload.php';
+
+if (! $included) {
+    echo 'You must set up the project dependencies, run the following commands:' . PHP_EOL
+       . 'curl -sS https://getcomposer.org/installer | php' . PHP_EOL
+       . 'php composer.phar install' . PHP_EOL;
+
+    exit(1);
+}
+
+if (empty($argv[1]) || !is_file($argv[1])) {
+    echo 'WARNING: Skipping commit message check because the Git hook was not ' . PHP_EOL
+       . 'passed the commit message file path; normally `.git/COMMIT_EDITMSG`' . PHP_EOL;
+
+    exit(1);
+}
+
+// Reference the required classes and the reviews you want to use.
+use League\CLImate\CLImate;
+use StaticReview\Issue\Issue;
+use StaticReview\Reporter\Reporter;
+use StaticReview\Review\Message\BodyLineLengthReview;
+use StaticReview\Review\Message\SubjectImperativeReview;
+use StaticReview\Review\Message\SubjectLineCapitalReview;
+use StaticReview\Review\Message\SubjectLineLengthReview;
+use StaticReview\Review\Message\SubjectLinePeriodReview;
+use StaticReview\Review\Message\WorkInProgressReview;
+use StaticReview\StaticReview;
+use StaticReview\VersionControl\GitVersionControl;
+
+$reporter = new Reporter();
+$climate  = new CLImate();
+$git      = new GitVersionControl();
+
+$review   = new StaticReview($reporter);
+
+// Add any reviews to the StaticReview instance, supports a fluent interface.
+$review->addReview(new BodyLineLengthReview())
+       ->addReview(new SubjectImperativeReview())
+       ->addReview(new SubjectLineCapitalReview())
+       ->addReview(new SubjectLineLengthReview())
+       ->addReview(new SubjectLinePeriodReview())
+       ->addReview(new WorkInProgressReview());
+
+// Check the commit message.
+$review->message($git->getCommitMessage($argv[1]));
+
+// Check if any matching issues were found.
+if ($reporter->hasIssues()) {
+    $climate->out('')->out('');
+
+    foreach ($reporter->getIssues() as $issue) {
+        $climate->red($issue);
+    }
+
+    $climate->out('')->red('✘ Please fix the errors above.');
+
+    exit(1);
+
+} else {
+    $climate->green('✔ That commit looks good!');
+
+    exit(0);
+}

--- a/src/Collection/ReviewCollection.php
+++ b/src/Collection/ReviewCollection.php
@@ -13,6 +13,7 @@
 
 namespace StaticReview\Collection;
 
+use StaticReview\Commit\CommitMessageInterface;
 use StaticReview\File\FileInterface;
 use StaticReview\Review\ReviewInterface;
 
@@ -61,6 +62,26 @@ class ReviewCollection extends Collection
     {
         $filter = function ($review) use ($file) {
             if ($review->canReview($file)) {
+                return true;
+            }
+
+            return false;
+        };
+
+        return $this->select($filter);
+    }
+
+    /**
+     * Returns a filtered ReviewCollection that should be run against the given
+     * message.
+     *
+     * @param  CommitMessage $message
+     * @return ReviewCollection
+     */
+    public function forMessage(CommitMessageInterface $message)
+    {
+        $filter = function ($review) use ($message) {
+            if ($review->canReview($message)) {
                 return true;
             }
 

--- a/src/Commit/CommitMessage.php
+++ b/src/Commit/CommitMessage.php
@@ -1,0 +1,92 @@
+<?php
+
+/*
+ * This file is part of StaticReview
+ *
+ * Copyright (c) 2014 Samuel Parkinson <@samparkinson_>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @see http://github.com/sjparkinson/static-review/blob/master/LICENSE
+ */
+
+namespace StaticReview\Commit;
+
+class CommitMessage implements CommitMessageInterface
+{
+    /**
+     * @var string Commit message subject.
+     */
+    protected $subject;
+
+    /**
+     * @var string Commit message body.
+     */
+    protected $body = '';
+
+    /**
+     * @var boolean Commit identifier.
+     */
+    protected $hash;
+
+    /**
+     * Initializes a new instance of the CommitMessage class.
+     *
+     * @param string $message
+     * @param string $hash
+     */
+    public function __construct($message, $hash = null)
+    {
+        $message = preg_replace('/^#.*/m', '', $message);
+        $message = preg_split('/(\r?\n)+/', trim($message));
+
+        $this->subject = array_shift($message);
+
+        if ($message) {
+            $this->body = implode("\n", $message);
+        }
+
+        $this->hash = $hash;
+    }
+
+    /**
+     * Get the commit message subject.
+     *
+     * @return string
+     */
+    public function getSubject()
+    {
+        return $this->subject;
+    }
+
+    /**
+     * Get the commit message body.
+     *
+     * @return string
+     */
+    public function getBody()
+    {
+        return $this->body;
+    }
+
+    /**
+     * Is the commit current or historical?
+     *
+     * @return string|null
+     */
+    public function getHash()
+    {
+        return $this->hash ?: null;
+    }
+
+    /**
+     * Get the reviewable name for the commit.
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->getHash() ?: 'current commit';
+    }
+}

--- a/src/Commit/CommitMessageInterface.php
+++ b/src/Commit/CommitMessageInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of StaticReview
+ *
+ * Copyright (c) 2015 Woody Gilk <@shadowhand>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @see http://github.com/sjparkinson/static-review/blob/master/LICENSE
+ */
+
+namespace StaticReview\Commit;
+
+use StaticReview\Review\ReviewableInterface;
+
+interface CommitMessageInterface extends ReviewableInterface
+{
+    public function getSubject();
+
+    public function getBody();
+
+    public function getHash();
+}

--- a/src/Review/AbstractFileReview.php
+++ b/src/Review/AbstractFileReview.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of StaticReview
+ *
+ * Copyright (c) 2015 Woody Gilk <@shadowhand>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @see http://github.com/sjparkinson/static-review/blob/master/LICENSE
+ */
+
+namespace StaticReview\Review;
+
+use StaticReview\Commit\CommitMessageInterface;
+use Symfony\Component\Process\Process;
+
+abstract class AbstractFileReview extends AbstractReview
+{
+    protected function canReviewMessage(CommitMessageInterface $message)
+    {
+        return false;
+    }
+}

--- a/src/Review/AbstractMessageReview.php
+++ b/src/Review/AbstractMessageReview.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of StaticReview
+ *
+ * Copyright (c) 2015 Woody Gilk <@shadowhand>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @see http://github.com/sjparkinson/static-review/blob/master/LICENSE
+ */
+
+namespace StaticReview\Review;
+
+use StaticReview\Commit\CommitMessageInterface;
+use StaticReview\File\FileInterface;
+use Symfony\Component\Process\Process;
+
+abstract class AbstractMessageReview extends AbstractReview
+{
+    protected function canReviewFile(FileInterface $file)
+    {
+        return false;
+    }
+
+    protected function canReviewMessage(CommitMessageInterface $message)
+    {
+        return true;
+    }
+}

--- a/src/Review/AbstractReview.php
+++ b/src/Review/AbstractReview.php
@@ -14,11 +14,14 @@
 namespace StaticReview\Review;
 
 use StaticReview\File\FileInterface;
+use StaticReview\Commit\CommitMessageInterface;
 use Symfony\Component\Process\Process;
 
 abstract class AbstractReview implements ReviewInterface
 {
     abstract protected function canReviewFile(FileInterface $file);
+
+    abstract protected function canReviewMessage(CommitMessageInterface $message);
 
     /**
      * Determine if the subject can be reviewed.
@@ -28,7 +31,13 @@ abstract class AbstractReview implements ReviewInterface
      */
     public function canReview(ReviewableInterface $subject)
     {
-        return $this->canReviewFile($subject);
+        if ($subject instanceof FileInterface) {
+            return $this->canReviewFile($subject);
+        }
+        if ($subject instanceof CommitMessageInterface) {
+            return $this->canReviewMessage($subject);
+        }
+        return false;
     }
 
     /**

--- a/src/Review/Composer/ComposerLintReview.php
+++ b/src/Review/Composer/ComposerLintReview.php
@@ -15,10 +15,10 @@ namespace StaticReview\Review\Composer;
 
 use StaticReview\File\FileInterface;
 use StaticReview\Reporter\ReporterInterface;
-use StaticReview\Review\AbstractReview;
+use StaticReview\Review\AbstractFileReview;
 use StaticReview\Review\ReviewableInterface;
 
-class ComposerLintReview extends AbstractReview
+class ComposerLintReview extends AbstractFileReview
 {
     /**
      * Lint only the composer.json file.

--- a/src/Review/Composer/ComposerSecurityReview.php
+++ b/src/Review/Composer/ComposerSecurityReview.php
@@ -15,10 +15,10 @@ namespace StaticReview\Review\Composer;
 
 use StaticReview\File\FileInterface;
 use StaticReview\Reporter\ReporterInterface;
-use StaticReview\Review\AbstractReview;
+use StaticReview\Review\AbstractFileReview;
 use StaticReview\Review\ReviewableInterface;
 
-class ComposerSecurityReview extends AbstractReview
+class ComposerSecurityReview extends AbstractFileReview
 {
     /**
      * Check the composer.lock file for security issues.

--- a/src/Review/General/LineEndingsReview.php
+++ b/src/Review/General/LineEndingsReview.php
@@ -15,10 +15,10 @@ namespace StaticReview\Review\General;
 
 use StaticReview\File\FileInterface;
 use StaticReview\Reporter\ReporterInterface;
-use StaticReview\Review\AbstractReview;
+use StaticReview\Review\AbstractFileReview;
 use StaticReview\Review\ReviewableInterface;
 
-class LineEndingsReview extends AbstractReview
+class LineEndingsReview extends AbstractFileReview
 {
     /**
      * Review any text based file.

--- a/src/Review/General/NoCommitTagReview.php
+++ b/src/Review/General/NoCommitTagReview.php
@@ -15,10 +15,10 @@ namespace StaticReview\Review\General;
 
 use StaticReview\File\FileInterface;
 use StaticReview\Reporter\ReporterInterface;
-use StaticReview\Review\AbstractReview;
+use StaticReview\Review\AbstractFileReview;
 use StaticReview\Review\ReviewableInterface;
 
-class NoCommitTagReview extends AbstractReview
+class NoCommitTagReview extends AbstractFileReview
 {
     /**
      * Review any text based file.

--- a/src/Review/Message/BodyLineLengthReview.php
+++ b/src/Review/Message/BodyLineLengthReview.php
@@ -1,0 +1,86 @@
+<?php
+
+/*
+ * This file is part of StaticReview
+ *
+ * Copyright (c) 2015 Woody Gilk <@shadowhand>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @see http://github.com/sjparkinson/static-review/blob/master/LICENSE
+ */
+
+namespace StaticReview\Review\Message;
+
+use StaticReview\Reporter\ReporterInterface;
+use StaticReview\Review\AbstractMessageReview;
+use StaticReview\Review\ReviewableInterface;
+
+/**
+ * Rule 6: Wrap the body at 72 characters
+ *
+ * <http://chris.beams.io/posts/git-commit/#wrap-72>
+ */
+class BodyLineLengthReview extends AbstractMessageReview
+{
+    /**
+     * @var integer Allowed length limit.
+     */
+    protected $maximum = 72;
+
+    /**
+     * @var boolean Allow long URLs to exceed the maximum.
+     */
+    protected $urls = true;
+
+    public function setMaximumLength($length)
+    {
+        $this->maximum = $length;
+    }
+
+    public function getMaximumLength()
+    {
+        return $this->maximum;
+    }
+
+    public function setAllowLongUrls($enable)
+    {
+        $this->urls = (bool) $enable;
+    }
+
+    public function getAllowLongUrls()
+    {
+        return $this->urls;
+    }
+
+    private function isLineTooLong($line)
+    {
+        return strlen($line) > $this->getMaximumLength();
+    }
+
+    private function doesContainUrl($line)
+    {
+        if ($this->getAllowLongUrls()) {
+            // It might contain a URL, but URL checking is disabled.
+            return false;
+        }
+
+        return strpos($line, '://') !== false;
+    }
+
+    public function review(ReporterInterface $reporter, ReviewableInterface $commit)
+    {
+        $lines = preg_split('/(\r?\n)+/', $commit->getBody());
+        foreach ($lines as $line) {
+            if ($this->isLineTooLong($line) && !$this->doesContainUrl($line)) {
+                $message = sprintf(
+                    'Body line is greater than %d characters ( "%s ..." )',
+                    $this->getMaximumLength(),
+                    substr($line, 0, 16)
+                );
+                $reporter->error($message, $this, $commit);
+            }
+        }
+    }
+}

--- a/src/Review/Message/SubjectImperativeReview.php
+++ b/src/Review/Message/SubjectImperativeReview.php
@@ -1,0 +1,105 @@
+<?php
+
+/*
+ * This file is part of StaticReview
+ *
+ * Copyright (c) 2015 Woody Gilk <@shadowhand>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @see http://github.com/sjparkinson/static-review/blob/master/LICENSE
+ */
+
+namespace StaticReview\Review\Message;
+
+use StaticReview\Reporter\ReporterInterface;
+use StaticReview\Review\AbstractMessageReview;
+use StaticReview\Review\ReviewableInterface;
+
+/**
+ * Rule 5: Use the imperative mood in the subject line.
+ *
+ * <http://chris.beams.io/posts/git-commit/#imperative>
+ *
+ * [Word list][1] taken from [m1foley/fit-commit][2] by Mike Foley.
+ *
+ * [1]: http://git.io/vnzxb
+ * [2]: https://github.com/m1foley/fit-commit/
+ */
+class SubjectImperativeReview extends AbstractMessageReview
+{
+    /**
+     * @var array Words in the wrong tense.
+     */
+    protected $incorrect = [
+        // Taken from m1foley/fit-commit
+        // Copyright (c) 2015 Mike Foley
+        'adds',       'adding',       'added',
+        'allows',     'allowing',     'allowed',
+        'amends',     'amending',     'amended',
+        'bumps',      'bumping',      'bumped',
+        'calculates', 'calculating',  'calculated',
+        'changes',    'changing',     'changed',
+        'cleans',     'cleaning',     'cleaned',
+        'commits',    'committing',   'committed',
+        'corrects',   'correcting',   'corrected',
+        'creates',    'creating',     'created',
+        'darkens',    'darkening',    'darkened',
+        'disables',   'disabling',    'disabled',
+        'displays',   'displaying',   'displayed',
+        'drys',       'drying',       'dryed',
+        'ends',       'ending',       'ended',
+        'enforces',   'enforcing',    'enforced',
+        'enqueues',   'enqueuing',    'enqueued',
+        'extracts',   'extracting',   'extracted',
+        'finishes',   'finishing',    'finished',
+        'fixes',      'fixing',       'fixed',
+        'formats',    'formatting',   'formatted',
+        'guards',     'guarding',     'guarded',
+        'handles',    'handling',     'handled',
+        'hides',      'hiding',       'hid',
+        'increases',  'increasing',   'increased',
+        'ignores',    'ignoring',     'ignored',
+        'implements', 'implementing', 'implemented',
+        'improves',   'improving',    'improved',
+        'keeps',      'keeping',      'kept',
+        'kills',      'killing',      'killed',
+        'makes',      'making',       'made',
+        'merges',     'merging',      'merged',
+        'moves',      'moving',       'moved',
+        'permits',    'permitting',   'permitted',
+        'prevents',   'preventing',   'prevented',
+        'pushes',     'pushing',      'pushed',
+        'rebases',    'rebasing',     'rebased',
+        'refactors',  'refactoring',  'refactored',
+        'removes',    'removing',     'removed',
+        'renames',    'renaming',     'renamed',
+        'reorders',   'reordering',   'reordered',
+        'requires',   'requiring',    'required',
+        'restores',   'restoring',    'restored',
+        'sends',      'sending',      'sent',
+        'sets',       'setting',
+        'separates',  'separating',   'separated',
+        'shows',      'showing',      'showed',
+        'skips',      'skipping',     'skipped',
+        'sorts',      'sorting',
+        'speeds',     'speeding',     'sped',
+        'starts',     'starting',     'started',
+        'supports',   'supporting',   'supported',
+        'takes',      'taking',       'took',
+        'tests',      'testing',      'tested',
+        'truncates',  'truncating',   'truncated',
+        'updates',    'updating',     'updated',
+        'uses',       'using',        'used',
+    ];
+
+    public function review(ReporterInterface $reporter, ReviewableInterface $commit)
+    {
+        $regex = '/^(?:' . implode('|', $this->incorrect) . ')/i';
+        if (preg_match($regex, $commit->getSubject())) {
+            $message = 'Subject line must use imperative present tense';
+            $reporter->error($message, $this, $commit);
+        }
+    }
+}

--- a/src/Review/Message/SubjectLineCapitalReview.php
+++ b/src/Review/Message/SubjectLineCapitalReview.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of StaticReview
+ *
+ * Copyright (c) 2015 Woody Gilk <@shadowhand>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @see http://github.com/sjparkinson/static-review/blob/master/LICENSE
+ */
+
+namespace StaticReview\Review\Message;
+
+use StaticReview\Reporter\ReporterInterface;
+use StaticReview\Review\AbstractMessageReview;
+use StaticReview\Review\ReviewableInterface;
+
+/**
+ * Rule 3: Capitalize the subject line
+ *
+ * <http://chris.beams.io/posts/git-commit/#capitalize>
+ */
+class SubjectLineCapitalReview extends AbstractMessageReview
+{
+    public function review(ReporterInterface $reporter, ReviewableInterface $commit)
+    {
+        if (!preg_match('/^[A-Z]/u', $commit->getSubject())) {
+            $message = 'Subject line must begin with a capital letter';
+            $reporter->error($message, $this, $commit);
+        }
+    }
+}

--- a/src/Review/Message/SubjectLineLengthReview.php
+++ b/src/Review/Message/SubjectLineLengthReview.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of StaticReview
+ *
+ * Copyright (c) 2015 Woody Gilk <@shadowhand>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @see http://github.com/sjparkinson/static-review/blob/master/LICENSE
+ */
+
+namespace StaticReview\Review\Message;
+
+use StaticReview\Reporter\ReporterInterface;
+use StaticReview\Review\AbstractMessageReview;
+use StaticReview\Review\ReviewableInterface;
+
+/**
+ * Rule 2: Limit the subject line to 50 characters
+ *
+ * <http://chris.beams.io/posts/git-commit/#limit-50>
+ */
+class SubjectLineLengthReview extends AbstractMessageReview
+{
+    /**
+     * @var integer Allowed length limit.
+     */
+    protected $maximum = 50;
+
+    public function setMaximumLength($length)
+    {
+        $this->maximum = $length;
+    }
+
+    public function getMaximumLength()
+    {
+        return $this->maximum;
+    }
+
+    public function review(ReporterInterface $reporter, ReviewableInterface $commit)
+    {
+        if (strlen($commit->getSubject()) > $this->getMaximumLength()) {
+            $message = sprintf(
+                'Subject line is greater than %d characters',
+                $this->getMaximumLength()
+            );
+            $reporter->error($message, $this, $commit);
+        }
+    }
+}

--- a/src/Review/Message/SubjectLinePeriodReview.php
+++ b/src/Review/Message/SubjectLinePeriodReview.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of StaticReview
+ *
+ * Copyright (c) 2015 Woody Gilk <@shadowhand>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @see http://github.com/sjparkinson/static-review/blob/master/LICENSE
+ */
+
+namespace StaticReview\Review\Message;
+
+use StaticReview\Reporter\ReporterInterface;
+use StaticReview\Review\AbstractMessageReview;
+use StaticReview\Review\ReviewableInterface;
+
+/**
+ * Rule 4: Do not end the subject line with a period
+ *
+ * <http://chris.beams.io/posts/git-commit/#end>
+ */
+class SubjectLinePeriodReview extends AbstractMessageReview
+{
+    public function review(ReporterInterface $reporter, ReviewableInterface $commit)
+    {
+        if (substr($commit->getSubject(), -1) === '.') {
+            $message = 'Subject line must not end with a period';
+            $reporter->error($message, $this, $commit);
+        }
+    }
+}

--- a/src/Review/Message/WorkInProgressReview.php
+++ b/src/Review/Message/WorkInProgressReview.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of StaticReview
+ *
+ * Copyright (c) 2015 Woody Gilk <@shadowhand>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @see http://github.com/sjparkinson/static-review/blob/master/LICENSE
+ */
+
+namespace StaticReview\Review\Message;
+
+use StaticReview\Reporter\ReporterInterface;
+use StaticReview\Review\AbstractMessageReview;
+use StaticReview\Review\ReviewableInterface;
+
+class WorkInProgressReview extends AbstractMessageReview
+{
+    public function review(ReporterInterface $reporter, ReviewableInterface $commit)
+    {
+        $fulltext = $commit->getSubject() . PHP_EOL . $commit->getBody();
+
+        if (preg_match('/\bwip\b/i', $fulltext)) {
+            $message = 'Do not commit WIP to shared branches';
+            $reporter->error($message, $this, $commit);
+        }
+    }
+}

--- a/src/Review/PHP/PhpCodeSnifferReview.php
+++ b/src/Review/PHP/PhpCodeSnifferReview.php
@@ -15,10 +15,10 @@ namespace StaticReview\Review\PHP;
 
 use StaticReview\File\FileInterface;
 use StaticReview\Reporter\ReporterInterface;
-use StaticReview\Review\AbstractReview;
+use StaticReview\Review\AbstractFileReview;
 use StaticReview\Review\ReviewableInterface;
 
-class PhpCodeSnifferReview extends AbstractReview
+class PhpCodeSnifferReview extends AbstractFileReview
 {
     protected $options = [];
 

--- a/src/Review/PHP/PhpLeadingLineReview.php
+++ b/src/Review/PHP/PhpLeadingLineReview.php
@@ -15,10 +15,10 @@ namespace StaticReview\Review\PHP;
 
 use StaticReview\File\FileInterface;
 use StaticReview\Reporter\ReporterInterface;
-use StaticReview\Review\AbstractReview;
+use StaticReview\Review\AbstractFileReview;
 use StaticReview\Review\ReviewableInterface;
 
-class PhpLeadingLineReview extends AbstractReview
+class PhpLeadingLineReview extends AbstractFileReview
 {
     /**
      * Determins if the given file should be revewed.

--- a/src/Review/PHP/PhpLintReview.php
+++ b/src/Review/PHP/PhpLintReview.php
@@ -15,10 +15,10 @@ namespace StaticReview\Review\PHP;
 
 use StaticReview\File\FileInterface;
 use StaticReview\Reporter\ReporterInterface;
-use StaticReview\Review\AbstractReview;
+use StaticReview\Review\AbstractFileReview;
 use StaticReview\Review\ReviewableInterface;
 
-class PhpLintReview extends AbstractReview
+class PhpLintReview extends AbstractFileReview
 {
     /**
      * Determins if a given file should be reviewed.

--- a/src/StaticReview.php
+++ b/src/StaticReview.php
@@ -15,6 +15,7 @@ namespace StaticReview;
 
 use StaticReview\Collection\FileCollection;
 use StaticReview\Collection\ReviewCollection;
+use StaticReview\Commit\CommitMessageInterface;
 use StaticReview\Reporter\ReporterInterface;
 use StaticReview\Review\ReviewInterface;
 
@@ -116,7 +117,20 @@ class StaticReview
             foreach ($this->getReviews()->forFile($file) as $review) {
                 $review->review($this->getReporter(), $file);
             }
+        }
 
+        return $this;
+    }
+
+    /**
+     * Runs through each review on the commit, collecting any errors.
+     *
+     * @return StaticReview
+     */
+    public function message(CommitMessageInterface $message)
+    {
+        foreach ($this->getReviews()->forMessage($message) as $review) {
+            $review->review($this->getReporter(), $message);
         }
 
         return $this;

--- a/src/VersionControl/GitVersionControl.php
+++ b/src/VersionControl/GitVersionControl.php
@@ -14,6 +14,7 @@
 namespace StaticReview\VersionControl;
 
 use StaticReview\Collection\FileCollection;
+use StaticReview\Commit\CommitMessage;
 use StaticReview\File\File;
 use StaticReview\File\FileInterface;
 use Symfony\Component\Process\Process;
@@ -49,6 +50,26 @@ class GitVersionControl implements VersionControlInterface
         }
 
         return $files;
+    }
+
+    /**
+     * Get a commit message by file or log.
+     *
+     * If no file name is provided, the last commit message will be used.
+     *
+     * @param  string $file
+     * @return CommitMessage
+     */
+    public function getCommitMessage($file = null)
+    {
+        if ($file) {
+            $hash = null;
+            $message = file_get_contents($file);
+        } else {
+            list($hash, $message) = explode(PHP_EOL, $this->getLastCommitMessage(), 2);
+        }
+
+        return new CommitMessage($message, $hash);
     }
 
     /**
@@ -102,5 +123,21 @@ class GitVersionControl implements VersionControlInterface
         $file->setCachedPath($cachedPath);
 
         return $file;
+    }
+
+    /**
+     * Get the last commit message subject and body.
+     *
+     * @return string
+     */
+    private function getLastCommitMessage()
+    {
+        // hash
+        // subject
+        // body
+        $process = new Process('git log -1 --format="%h%n%s%n%b"');
+        $process->run();
+
+        return trim($process->getOutput());
     }
 }

--- a/tests/unit/Review/AbstractReviewTest.php
+++ b/tests/unit/Review/AbstractReviewTest.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of StaticReview
  *
- * Copyright (c) 2014 Samuel Parkinson <@samparkinson_>
+ * Copyright (c) 2015 Woody Gilk <@shadowhand>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.


### PR DESCRIPTION
Add new reviewable type `CommitMessageInterface` and add a `commit-msg` hook example.

Includes a number of commit message tests that satisfy the rules laid out by Chris Beams in <http://chris.beams.io/posts/git-commit/>.

Should be rebased/merged after #41 is complete.