### PR TITLE
Do not abort commits during message review

### DIFF
--- a/hooks/static-review-commit-msg.php
+++ b/hooks/static-review-commit-msg.php
@@ -69,9 +69,9 @@ if ($reporter->hasIssues()) {
         $climate->red($issue);
     }
 
-    $climate->out('')->red('✘ Please fix the errors above.');
+    $climate->out('')->red('✘ Please fix the errors above using: git commit --amend');
 
-    exit(1);
+    exit(0);
 
 } else {
     $climate->green('✔ That commit looks good!');


### PR DESCRIPTION
One of my coworkers pointed out how annoying it is to completely lose your commit message when the review is rejected. Instead of aborting the commit, display the errors and prompt the user to correct them.

Refs #42