### PR TITLE
Prevent bad matches when running imperative check

### DIFF
--- a/src/Review/Message/SubjectImperativeReview.php
+++ b/src/Review/Message/SubjectImperativeReview.php
@@ -96,7 +96,7 @@ class SubjectImperativeReview extends AbstractMessageReview
 
     public function review(ReporterInterface $reporter, ReviewableInterface $commit)
     {
-        $regex = '/^(?:' . implode('|', $this->incorrect) . ')/i';
+        $regex = '/^(?:' . implode('|', $this->incorrect) . ')\b/i';
         if (preg_match($regex, $commit->getSubject())) {
             $message = 'Subject line must use imperative present tense';
             $reporter->error($message, $this, $commit);


### PR DESCRIPTION
Because there was no word termination, "hid" was being matched for "hide". The latter is imperative and should pass review.

Fixes #49