### PR TITLE
Allow global tools to be used for processes

### DIFF
--- a/src/Review/AbstractReview.php
+++ b/src/Review/AbstractReview.php
@@ -58,6 +58,34 @@ abstract class AbstractReview implements ReviewInterface
         $timeout = 60,
         array $options = []
     ) {
+        if (null === $cwd) {
+            $cwd = $this->getRootDirectory();
+        }
         return new Process($commandline, $cwd, $env, $input, $timeout, $options);
+    }
+
+    /**
+     * Get the root directory for a process command.
+     *
+     * @return string
+     */
+    private function getRootDirectory()
+    {
+        static $root;
+
+        if (!$root) {
+            $working = getcwd();
+            $myself  = __DIR__;
+
+            if (0 === strpos($myself, $working)) {
+                // Local installation, the working directory is the root
+                $root = $working;
+            } else {
+                // Global installation, back up above the vendor/ directory
+                $root = realpath($myself . '/../../../../../');
+            }
+        }
+
+        return $root;
     }
 }

--- a/tests/unit/Review/AbstractReviewTest.php
+++ b/tests/unit/Review/AbstractReviewTest.php
@@ -26,4 +26,29 @@ class AbstractReviewTest extends TestCase
 
         $this->assertInstanceOf('Symfony\Component\Process\Process', $process);
     }
+
+    public function testGetProcessWorkingDirectory()
+    {
+        $review = Mockery::mock('StaticReview\Review\AbstractReview')->makePartial();
+
+        $process = $review->getProcess('whoami');
+
+        // By default, the working directory should be the current directory.
+        $this->assertSame(getcwd(), $process->getWorkingDirectory());
+
+        $cwd = getcwd();
+
+        // Move out of the current working directory, which should cause the
+        // process root directory to match the original root rather than the
+        // current directory. This is done to handle global installation.
+        chdir(sys_get_temp_dir());
+
+        $process = $review->getProcess('whoami');
+
+        $this->assertSame($cwd, $process->getWorkingDirectory());
+        $this->assertNotSame(getcwd(), $process->getWorkingDirectory());
+
+        // Restore original working directory.
+        chdir($cwd);
+    }
 }


### PR DESCRIPTION
Sets the `$cwd` of `Process` commands based on whether or not the
current working directory matches with the installation path.

Fixes #27
Refs #46