### PR TITLE
Enable verbose commit message parsing

### DIFF
--- a/src/Commit/CommitMessage.php
+++ b/src/Commit/CommitMessage.php
@@ -38,7 +38,14 @@ class CommitMessage implements CommitMessageInterface
      */
     public function __construct($message, $hash = null)
     {
+        // Strip out the diff that is included in the commit message when
+        // using `git commit -v` as we should not check it as text.
+        list($message) = preg_split('/# \-+ >8 \-+/', $message, 2);
+
+        // Remove all comment lines from the message
         $message = preg_replace('/^#.*/m', '', $message);
+
+        // Split the message by newlines
         $message = preg_split('/(\r?\n)+/', trim($message));
 
         $this->subject = array_shift($message);

--- a/tests/fixtures/commit-message-subject-and-body-and-comments.txt
+++ b/tests/fixtures/commit-message-subject-and-body-and-comments.txt
@@ -1,0 +1,14 @@
+Create a better commit message
+
+# Comment in the middle of things too
+
+We have the tools.
+
+# Please enter the commit message for your changes. Lines starting
+# with '#' will be ignored, and an empty message aborts the commit.
+# On branch hotfix/commit-msg-verbose
+# Your branch is up-to-date with 'master'.
+#
+# Changes to be committed:
+#	modified:   src/Commit/CommitMessage.php
+#

--- a/tests/fixtures/commit-message-subject-and-body-and-diff.txt
+++ b/tests/fixtures/commit-message-subject-and-body-and-diff.txt
@@ -1,0 +1,28 @@
+Create a better commit message
+
+# Comment in the middle of things too
+
+We have the tools.
+
+# Please enter the commit message for your changes. Lines starting
+# with '#' will be ignored, and an empty message aborts the commit.
+# On branch hotfix/commit-msg-verbose
+# Your branch is up-to-date with 'master'.
+#
+# Changes to be committed:
+#	modified:   src/Commit/CommitMessage.php
+#
+# ------------------------ >8 ------------------------
+# Do not touch the line above.
+# Everything below will be removed.
+diff --git a/src/Commit/CommitMessage.php b/src/Commit/CommitMessage.php
+index dd4f6d2..5809d37 100644
+--- a/src/Commit/CommitMessage.php
++++ b/src/Commit/CommitMessage.php
+@@ -38,6 +38,7 @@ class CommitMessage implements CommitMessageInterface
+      */
+     public function __construct($message, $hash = null)
+     {
++        list($message) = preg_split('/^# \-+ >8 \-+/', $message, 2);
+         $message = preg_replace('/^#.*/m', '', $message);
+         $message = preg_split('/(\r?\n)+/', trim($message));

--- a/tests/fixtures/commit-message-subject-and-body.txt
+++ b/tests/fixtures/commit-message-subject-and-body.txt
@@ -1,0 +1,3 @@
+Create a better commit message
+
+We have the tools.

--- a/tests/fixtures/commit-message-subject-only.txt
+++ b/tests/fixtures/commit-message-subject-only.txt
@@ -1,0 +1,1 @@
+Create a better commit message

--- a/tests/unit/Commit/CommitMessage.php
+++ b/tests/unit/Commit/CommitMessage.php
@@ -1,0 +1,78 @@
+<?php
+
+/*
+ * This file is part of StaticReview
+ *
+ * Copyright (c) 2015 Woody Gilk <@shadowhand>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @see http://github.com/sjparkinson/static-review/blob/master/LICENSE
+ */
+
+namespace StaticReview\Test\Unit\Commit;
+
+use StaticReview\Commit\CommitMessage;
+
+use Mockery;
+use PHPUnit_Framework_TestCase as TestCase;
+
+class CommitMessageTest extends TestCase
+{
+    /**
+     * @var string Directory that contains fixtures
+     */
+    private $fixtures;
+
+    public function setUp()
+    {
+        $this->fixtures = realpath(__DIR__ . '/../../fixtures');
+    }
+
+    /**
+     * Get a commit message fixture by name
+     *
+     * @param string $name
+     *
+     * @return string
+     */
+    private function message($name)
+    {
+        return file_get_contents($this->fixtures . '/commit-message-' . $name . '.txt');
+    }
+
+    public function testConstructionSubjectOnly()
+    {
+        $commit = new CommitMessage($this->message('subject-only'));
+
+        $this->assertSame('Create a better commit message', $commit->getSubject());
+        $this->assertSame('', $commit->getBody());
+    }
+
+    public function testConstructionSubjectAndBody()
+    {
+        $commit = new CommitMessage($this->message('subject-and-body'));
+
+        $this->assertSame('Create a better commit message', $commit->getSubject());
+        $this->assertSame('We have the tools.', $commit->getBody());
+    }
+
+    public function testConstructionSubjectAndBodyAndComments()
+    {
+        $commit = new CommitMessage($this->message('subject-and-body-and-comments'));
+
+        // Nothing should be different, the comments should be stripped
+        $this->assertSame('Create a better commit message', $commit->getSubject());
+        $this->assertSame('We have the tools.', $commit->getBody());
+    }
+
+    public function testConstructionSubjectAndBodyAndDiff()
+    {
+        $commit = new CommitMessage($this->message('subject-and-body-and-diff'));
+
+        // Nothing should be different, the diff should be stripped
+        $this->assertSame('Create a better commit message', $commit->getSubject());
+        $this->assertSame('We have the tools.', $commit->getBody());
+    }
+}


### PR DESCRIPTION
When using `git commit -v` a diff of the changes is appended to the end
of the message. Remove this diff when parsing the commit message.

Also adds tests for parsing commit messages.

Refs #7