### PR TITLE
Update to support PHP 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,18 +3,14 @@ language: php
 sudo: false
 
 php:
-  - 5.5
   - 5.6
   - 7.0
   - hhvm
 
 matrix:
   include:
-    - php: 5.5
+    - php: 5.6
       env: 'COMPOSER_FLAGS="--prefer-stable --prefer-lowest"'
-  allow_failures:
-    - php: 7.0
-  fast_finish: true
 
 before_script:
   - git config --global user.name travis-ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,14 @@ language: php
 sudo: false
 
 php:
+  - 5.5
   - 5.6
   - 7.0
   - hhvm
 
 matrix:
   include:
-    - php: 5.6
+    - php: 5.5
       env: 'COMPOSER_FLAGS="--prefer-stable --prefer-lowest"'
 
 before_script:

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -17,7 +17,6 @@
 
 Vagrant.configure("2") do |config|
 
-    version = "php5-5.6"
     hostname = "php.box"
     locale = "en_GB.UTF.8"
 
@@ -34,8 +33,8 @@ Vagrant.configure("2") do |config|
     config.vm.provision :shell, :inline => "apt-get install -q -y g++ make git curl vim"
 
     # Lang
-    config.vm.provision :shell, :inline => "add-apt-repository ppa:ondrej/#{version} && apt-get update"
-    config.vm.provision :shell, :inline => "apt-get install -q -y php5-dev php5-cli php5-curl php5-xdebug"
+    config.vm.provision :shell, :inline => "add-apt-repository ppa:ondrej/php && apt-get update"
+    config.vm.provision :shell, :inline => "apt-get install -q -y php7.0-dev php7.0-cli php7.0-curl php-xdebug"
     config.vm.provision :shell, :inline => "curl -s https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer"
 
     # Git Setup

--- a/composer.json
+++ b/composer.json
@@ -45,9 +45,9 @@
 
     "require-dev": {
         "mockery/mockery": "^0.9",
-        "phpunit/phpunit": "^4.0 || ^5.0",
+        "phpunit/phpunit": "^4.6 || ^5.0",
         "sensiolabs/security-checker": "^3.0",
-        "squizlabs/php_codesniffer": "^2.0"
+        "squizlabs/php_codesniffer": "^2.2"
     },
 
     "suggest": {
@@ -57,7 +57,7 @@
 
     "scripts": {
         "test": [
-            "vendor/bin/phpcs --standard=PSR2 src/ bin/ hooks/ tests/",
+            "vendor/bin/phpcs --colors --standard=PSR2 src/ bin/ hooks/ tests/",
             "vendor/bin/phpunit --color=always --testsuite unit",
             "vendor/bin/phpunit --color=always --testsuite functional"
         ]

--- a/composer.json
+++ b/composer.json
@@ -37,17 +37,17 @@
     ],
 
     "require": {
-        "php": ">=5.5",
-        "league/climate": "^2.0|^3.0",
+        "php": "^5.6 || ^7.0",
+        "league/climate": "^2.0 || ^3.0",
         "symfony/console": "^2.0",
         "symfony/process": "^2.1"
     },
 
     "require-dev": {
         "mockery/mockery": "^0.9",
-        "phpunit/phpunit": "^4.0",
+        "phpunit/phpunit": "^5.1",
         "sensiolabs/security-checker": "^3.0",
-        "squizlabs/php_codesniffer": "^2.0"
+        "squizlabs/php_codesniffer": "^2.5"
     },
 
     "suggest": {
@@ -57,9 +57,9 @@
 
     "scripts": {
         "test": [
-            "vendor/bin/phpcs  --standard=PSR2 src/ bin/ hooks/ tests/",
-            "vendor/bin/phpunit --testsuite unit",
-            "vendor/bin/phpunit --testsuite functional"
+            "vendor/bin/phpcs --colors --standard=PSR2 src/ bin/ hooks/ tests/",
+            "vendor/bin/phpunit --color=always --testsuite unit",
+            "vendor/bin/phpunit --color=always --testsuite functional"
         ]
     },
 

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
     ],
 
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^5.5 || ^7.0",
         "league/climate": "^2.0 || ^3.0",
         "symfony/console": "^2.0",
         "symfony/process": "^2.1"
@@ -45,9 +45,9 @@
 
     "require-dev": {
         "mockery/mockery": "^0.9",
-        "phpunit/phpunit": "^5.1",
+        "phpunit/phpunit": "^4.0 || ^5.0",
         "sensiolabs/security-checker": "^3.0",
-        "squizlabs/php_codesniffer": "^2.5"
+        "squizlabs/php_codesniffer": "^2.0"
     },
 
     "suggest": {
@@ -57,7 +57,7 @@
 
     "scripts": {
         "test": [
-            "vendor/bin/phpcs --colors --standard=PSR2 src/ bin/ hooks/ tests/",
+            "vendor/bin/phpcs --standard=PSR2 src/ bin/ hooks/ tests/",
             "vendor/bin/phpunit --color=always --testsuite unit",
             "vendor/bin/phpunit --color=always --testsuite functional"
         ]

--- a/tests/unit/Issue/IssueTest.php
+++ b/tests/unit/Issue/IssueTest.php
@@ -50,34 +50,6 @@ class IssueTest extends TestCase
         Mockery::close();
     }
 
-    /**
-     * @expectedException PHPUnit_Framework_Error
-     * @expectedExceptionMessage must implement interface StaticReview\Review\ReviewInterface
-     */
-    public function testConstructWithInvalidReview()
-    {
-        $issue = new Issue(
-            $this->issueLevel,
-            $this->issueMessage,
-            null,
-            $this->issueFile
-        );
-    }
-
-    /**
-     * @expectedException PHPUnit_Framework_Error
-     * @expectedExceptionMessage must implement interface StaticReview\Review\ReviewableInterface
-     */
-    public function testConstructWithInvalidFile()
-    {
-        $issue = new Issue(
-            $this->issueLevel,
-            $this->issueMessage,
-            $this->issueReview,
-            null
-        );
-    }
-
     public function testGetLevel()
     {
         $this->assertSame($this->issueLevel, $this->issue->getLevel());


### PR DESCRIPTION
* :arrow_up: Update PHP version requirements to `^5.6 || ^7.0`
* :arrow_up: Update the vagrant box to PHP 7.0
* :fire: Remove support for PHP 5.5
* :fire: Remove two failing tests that don't do much

Resolves https://github.com/sjparkinson/static-review/issues/59.