### PR TITLE
autoload.php file not found

### DIFF
--- a/bin/static-review.php
+++ b/bin/static-review.php
@@ -12,8 +12,8 @@
  * @see http://github.com/sjparkinson/static-review/blob/master/LICENSE
  */
 
-$included = include file_exists(__DIR__ . '/../vendor/autoload.php')
-    ? __DIR__ . '/../vendor/autoload.php'
+$included = include file_exists(__DIR__ . '/../autoload.php')
+    ? __DIR__ . '/../autoload.php'
     : __DIR__ . '/../../../autoload.php';
 
 if (! $included) {


### PR DESCRIPTION
When running `vendor/bin/static-review.php hook:install`:

```php
__DIR__ // vendor/bin
__DIR__ . '/..' // vendor
__DIR__ . '/../vendor/autoload.php' // vendor/vendor/autoload.php
```