### PR TITLE
Fix 'File must begin with <?php or #!/usr/bin/env php' error when renaming file

### DIFF
--- a/src/VersionControl/GitVersionControl.php
+++ b/src/VersionControl/GitVersionControl.php
@@ -40,7 +40,9 @@ class GitVersionControl implements VersionControlInterface
         $files = new FileCollection();
 
         foreach ($this->getFiles() as $file) {
-            list($status, $relativePath) = explode("\t", $file);
+            $fileData = explode("\t", $file);
+            $status = reset($fileData);
+            $relativePath = end($fileData);
 
             $fullPath = rtrim($base . DIRECTORY_SEPARATOR . $relativePath);
 

--- a/tests/functional/VersionControl/GitVersionControlTest.php
+++ b/tests/functional/VersionControl/GitVersionControlTest.php
@@ -148,4 +148,63 @@ class GitVersionControlTest extends TestCase
 
         $this->assertSame('test', trim($process->getOutput()));
     }
+
+    public function testGetStagedFilesWithMovedUnrenamedFile()
+    {
+        $testFolderName = 'test_folder';
+
+        $cmd  = 'touch ' . $this->testFileName;
+        $cmd .= ' && echo \'test\' > ' . $this->testFileName;
+        $cmd .= ' && git init';
+        $cmd .= ' && git add ' . $this->testFileName;
+        $cmd .= ' && git commit -m \'test\'';
+        $cmd .= ' && mkdir ' . $testFolderName;
+        $cmd .= ' && mv ' .  $this->testFileName . ' ' . $testFolderName;
+        $cmd .= ' && git add ' . $this->testFileName;
+        $cmd .= ' && git add ' . $testFolderName;
+
+        $process = new Process($cmd);
+        $process->run();
+
+        $git = new GitVersionControl();
+        $collection = $git->getStagedFiles();
+
+        $this->assertInstanceOf('StaticReview\Collection\FileCollection', $collection);
+        $this->assertCount(1, $collection);
+
+        $file = $collection->current();
+
+        $this->assertSame(basename($this->testFileName), $file->getFileName());
+        $this->assertStringStartsWith('R', $file->getStatus());
+    }
+
+    public function testGetStagedFilesWithMovedRenamedFile()
+    {
+        $testFolderName = 'test_folder';
+        $newTestFileName = 'test_new.txt';
+
+        $cmd  = 'touch ' . $this->testFileName;
+        $cmd .= ' && echo \'test\' > ' . $this->testFileName;
+        $cmd .= ' && git init';
+        $cmd .= ' && git add ' . $this->testFileName;
+        $cmd .= ' && git commit -m \'test\'';
+        $cmd .= ' && mkdir ' . $testFolderName;
+        $cmd .= ' && mv ' .  $this->testFileName . ' ' . $testFolderName . DIRECTORY_SEPARATOR . $newTestFileName;
+        $cmd .= ' && git add ' . $this->testFileName;
+        $cmd .= ' && git add ' . $testFolderName;
+
+        $process = new Process($cmd);
+        $process->run();
+
+        $git = new GitVersionControl();
+        $collection = $git->getStagedFiles();
+
+        $this->assertInstanceOf('StaticReview\Collection\FileCollection', $collection);
+        $this->assertCount(1, $collection);
+
+        $file = $collection->current();
+
+        $this->assertSame(basename($newTestFileName), $file->getFileName());
+        $this->assertStringStartsWith('R', $file->getStatus());
+    }
 }


### PR DESCRIPTION
Case:
```
adrianmartinez@MacBook-Pro-de-Adrian:/Users/adrianmartinez/Sites/magento2_2.2-develop (FR22#ADMIN-CMS-BLOCK-REPOSITORY +) $ git status
(...)
Changes to be committed:
  (use "git reset HEAD <file>..." to unstage)
	renamed:    app/code/Magento/Cms/Test/Unit/Controller/Block/InlineEditTest.php -> app/code/Magento/Cms/Test/Unit/Controller/Adminhtml/Block/InlineEditTest.php

adrianmartinez@MacBook-Pro-de-Adrian:/Users/adrianmartinez/Sites/magento2_2.2-develop (FR22#ADMIN-CMS-BLOCK-REPOSITORY +) $ git diff --cached --name-status --diff-filter=ACMR
R086    app/code/Magento/Cms/Test/Unit/Controller/Block/InlineEditTest.php      app/code/Magento/Cms/Test/Unit/Controller/Adminhtml/Block/InlineEditTest.php
```

Previous code assumed line will only had one tab char, and exploded data count is equal to 2, discarding the 3rd array position if it exists. In this case, $relativePath resulted in old path being checked, instead of the new, so `\StaticReview\Review\PHP\PhpLeadingLineReview::review` fails:
```
PhpLeadingLineReview Error: File must begin with `<?php` or `#!/usr/bin/env php` in app/code/Magento/Cms/Test/Unit/Controller/Block/InlineEditTest.php
```